### PR TITLE
Add HSDP support for multi-node training

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ cd muon_fsdp_2
 uv sync
 ```
 
+## Run FSDP (single node / multi GPU)
 run debug
 
 ```bash
@@ -108,6 +109,37 @@ old code not updated yet
 | 1B         | 8    | H100 sxm | 45% |
 | 7B         | 8    | H100 sxm | 49% |
 
+## Run HSDP (multi node / multi GPU)
+
+HSDP (Hybrid Sharded Data Parallel) combines data parallelism across nodes with FSDP within each node, providing better scaling for multi-node training.
+
+run debug (simulating 2 nodes with 1 GPU each on a single machine)
+
+```bash
+# Terminal 1 (node 0)
+CUDA_VISIBLE_DEVICES=0 uv run torchrun --nproc_per_node=1 --nnodes=2 --node_rank=0 \
+  --master_addr=<node0_ip> --master_port=<port> \
+  train_hsdp.py @ configs/debug/normal.toml
+
+# Terminal 2 (mimics a pseudo node 1, physically still node 0)
+CUDA_VISIBLE_DEVICES=1 uv run torchrun --nproc_per_node=1 --nnodes=2 --node_rank=1 \
+  --master_addr=<node0_ip> --master_port=<port> \
+  train_hsdp.py @ configs/debug/normal.toml
+```
+
+run 150M (2 nodes with 8 GPUs each)
+
+```bash
+# Node 0
+uv run torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 \
+  --master_addr=<node0_ip> --master_port=<port> \
+  train_hsdp.py @ configs/150M/H100.toml
+
+# Node 1
+uv run torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 \
+  --master_addr=<node0_ip> --master_port=<port> \
+  train_hsdp.py @ configs/150M/H100.toml
+```
 
 ## convergence 150M
 

--- a/src/muon/muon_fsdp2.py
+++ b/src/muon/muon_fsdp2.py
@@ -33,7 +33,7 @@ def nsloop_torch(X: torch.Tensor, steps: int, *, a=3.4445, b=-4.7750, c=2.0315):
         X = a * X + B @ X
     return X
 
-def zeropower_via_newtonschulz5(G, steps: int):
+def zeropower_via_newtonschulz5(G, steps: int, coeffs=(3.4445, -4.7750, 2.0315)):
     """
     Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
     quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
@@ -42,9 +42,14 @@ def zeropower_via_newtonschulz5(G, steps: int):
     on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
     where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
     performance at all relative to UV^T, where USV^T = G is the SVD.
+
+    coeffs: (a, b, c) for the quintic p(σ) = aσ + bσ³ + cσ⁵. Default is the
+        Jordan/YouJiacheng "max slope at zero" choice. Non-default values let
+        callers experiment with non-oscillatory polynomials (e.g. (1.875,
+        -1.25, 0.375), the super-convergent monotone quintic).
     """
     assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
-    a, b, c = (3.4445, -4.7750,  2.0315)
+    a, b, c = coeffs
     X = G.bfloat16()
     if G.size(-2) > G.size(-1):
         X = X.mT

--- a/src/muon/muon_fsdp2.py
+++ b/src/muon/muon_fsdp2.py
@@ -285,7 +285,7 @@ class Hsdp2dWork:
             scatter(
                 grad.to_local(),
                 scatter_list=chunks,
-                src=state['dest_fsdp_rank'],
+                group_src=state['dest_fsdp_rank'],
                 group=state['fsdp_pg'],
                 async_op=False
             )
@@ -294,7 +294,7 @@ class Hsdp2dWork:
             scatter(
                 grad.to_local(),
                 None,
-                src=state['dest_fsdp_rank'],
+                group_src=state['dest_fsdp_rank'],
                 group=state['fsdp_pg'],
                 async_op=False
             )

--- a/src/muon/muon_fsdp2.py
+++ b/src/muon/muon_fsdp2.py
@@ -161,7 +161,7 @@ class Fsdp1dWork:
         self.param.add_(update.reshape(self.param.shape), alpha=-self.group["lr"])
 
 
-class HsdpFsdp2dWork:
+class Hsdp2dWork:
     """
     Muon work for HSDP (Hybrid Sharded Data Parallel) with 2D mesh.
     Assumes mesh dimension 0 is for data parallelism (replicas across nodes)
@@ -414,7 +414,7 @@ class Muon(torch.optim.Optimizer):
     def _get_work_class(self, p: torch.Tensor) -> tuple[type[Work], int]:
         """
         dispatch the work class based on the mesh dimension.
-        For 2D mesh, uses HsdpFsdp2dWork which assumes:
+        For 2D mesh, uses Hsdp2dWork which assumes:
         - dim 0: replica/data parallel dimension (across nodes)
         - dim 1: FSDP dimension (sharding within nodes)
         """
@@ -422,7 +422,7 @@ class Muon(torch.optim.Optimizer):
             if p.device_mesh.ndim == 1:
                 return Fsdp1dWork, 8
             elif p.device_mesh.ndim == 2:
-                return HsdpFsdp2dWork, 8
+                return Hsdp2dWork, 8
             else:
                 raise ValueError(f"Unsupported mesh dimension: {p.device_mesh.ndim}")
         else:

--- a/src/muon/muon_fsdp2.py
+++ b/src/muon/muon_fsdp2.py
@@ -161,13 +161,159 @@ class Fsdp1dWork:
         self.param.add_(update.reshape(self.param.shape), alpha=-self.group["lr"])
 
 
-class TpFsdp2dWork:
+class HsdpFsdp2dWork:
     """
-    Muon work for TP + FSDP mesh
+    Muon work for HSDP (Hybrid Sharded Data Parallel) with 2D mesh.
+    Assumes mesh dimension 0 is for data parallelism (replicas across nodes)
+    and mesh dimension 1 is for FSDP (sharding within nodes).
+    
+    For example, with 2 nodes of 8 GPUs each:
+    - mesh shape: (2, 8)
+    - dim 0: replica group (2 nodes)
+    - dim 1: FSDP group (8 GPUs per node)
     """
     
     def __init__(self, param, state, group, index: int):
-        raise NotImplementedError("not implemented")
+        self.param = param
+        self.state = state
+        self.group = group
+        self.index = index
+        self._intermediate_state = None
+    
+    def start(self):
+        self.param.grad = apply_momentum(
+            self.param.grad,
+            self.state["momentum_buffer"],
+            self.group["momentum"],
+            self.group["nesterov"]
+        )
+        
+        grad = self.param.grad
+        assert isinstance(grad, DTensor), "only supports DTensor parameters"
+        assert grad.device_mesh.ndim == 2, "only supports 2D mesh for HSDP"
+        
+        device_mesh = grad.device_mesh
+        
+        # Get the FSDP dimension (typically dim 1)
+        # Assuming the mesh is structured as (replicas, fsdp_shards)
+        fsdp_dim = 1
+        replica_dim = 0
+        
+        # Get mesh information
+        mesh_coords = device_mesh.get_coordinate()
+        if mesh_coords is None:
+            raise RuntimeError("Could not get mesh coordinates")
+        
+        replica_rank = mesh_coords[replica_dim]
+        fsdp_rank = mesh_coords[fsdp_dim]
+        
+        replica_size = device_mesh.size(replica_dim)
+        fsdp_size = device_mesh.size(fsdp_dim)
+        
+        # Get process groups for each dimension
+        fsdp_pg = device_mesh.get_group(fsdp_dim)
+        replica_pg = device_mesh.get_group(replica_dim)
+        
+        # Determine which rank in the FSDP group will handle this parameter
+        dest_fsdp_rank = self.index % fsdp_size
+        
+        # Step 1: Gather within FSDP group (along fsdp_dim)
+        if fsdp_rank == dest_fsdp_rank:
+            gather_lists = [torch.zeros_like(grad.to_local()) for _ in range(fsdp_size)]
+            gather_handle = gather(
+                grad.to_local(),
+                gather_lists,
+                group_dst=dest_fsdp_rank,
+                group=fsdp_pg,
+                async_op=True
+            )
+        else:
+            gather_lists = None
+            gather_handle = gather(
+                grad.to_local(),
+                None,
+                group_dst=dest_fsdp_rank,
+                group=fsdp_pg,
+                async_op=True
+            )
+        
+        self._intermediate_state = {
+            'dest_fsdp_rank': dest_fsdp_rank,
+            'fsdp_rank': fsdp_rank,
+            'replica_rank': replica_rank,
+            'fsdp_size': fsdp_size,
+            'replica_size': replica_size,
+            'fsdp_pg': fsdp_pg,
+            'replica_pg': replica_pg,
+            'gather_handle': gather_handle,
+            'gather_lists': gather_lists,
+            'fsdp_dim': fsdp_dim,
+            'replica_dim': replica_dim
+        }
+    
+    def finish(self):
+        assert self._intermediate_state is not None, "start() must be called first"
+        
+        grad = self.param.grad
+        state = self._intermediate_state
+        
+        # Wait for FSDP gather to complete
+        state['gather_handle'].wait()
+        
+        # Step 2: Process on the designated rank within each replica
+        if state['fsdp_rank'] == state['dest_fsdp_rank']:
+            # Concatenate gathered gradients
+            g_full_block = torch.cat(state['gather_lists'], dim=0)
+            
+            # Step 3: All-reduce across replicas (data parallel dimension)
+            # Average the gradients across replicas
+            if state['replica_size'] > 1:
+                torch.distributed.all_reduce(
+                    g_full_block,
+                    op=torch.distributed.ReduceOp.AVG,
+                    group=state['replica_pg']
+                )
+            
+            # Step 4: Apply Newton-Schulz orthogonalization
+            g_full_block.copy_(
+                zeropower_via_newtonschulz5(g_full_block, self.group["ns_steps"])
+            )
+            g_full_block = g_full_block.type_as(grad)
+            
+            # Step 5: Scatter back within FSDP group
+            chunks = list(g_full_block.chunk(chunks=state['fsdp_size'], dim=0))
+            scatter(
+                grad.to_local(),
+                scatter_list=chunks,
+                src=state['dest_fsdp_rank'],
+                group=state['fsdp_pg'],
+                async_op=False
+            )
+        else:
+            # Other ranks in FSDP group just receive their chunk
+            scatter(
+                grad.to_local(),
+                None,
+                src=state['dest_fsdp_rank'],
+                group=state['fsdp_pg'],
+                async_op=False
+            )
+        
+        # Step 6: Apply scaling and update parameters
+        update = apply_scaling(grad, self.group["rms_scale"])
+        self.param.mul_(1 - self.group["lr"] * self.group["weight_decay"])
+        self.param.add_(update.reshape(self.param.shape), alpha=-self.group["lr"])
+        
+        self._intermediate_state = None
+
+
+class TpFsdp2dWork:
+    """
+    Muon work for TP + FSDP mesh (not yet implemented)
+    """
+    
+    def __init__(self, param, state, group, index: int):
+        raise NotImplementedError("TP + FSDP not implemented, use HsdpFsdp2dWork for HSDP")
     
 class EpFsdp2dWork:
     """
@@ -268,12 +414,15 @@ class Muon(torch.optim.Optimizer):
     def _get_work_class(self, p: torch.Tensor) -> tuple[type[Work], int]:
         """
         dispatch the work class based on the mesh dimension.
+        For 2D mesh, uses HsdpFsdp2dWork which assumes:
+        - dim 0: replica/data parallel dimension (across nodes)
+        - dim 1: FSDP dimension (sharding within nodes)
         """
         if isinstance(p, DTensor):
             if p.device_mesh.ndim == 1:
                 return Fsdp1dWork, 8
             elif p.device_mesh.ndim == 2:
-                return TpFsdp2dWork, 8
+                return HsdpFsdp2dWork, 8
             else:
                 raise ValueError(f"Unsupported mesh dimension: {p.device_mesh.ndim}")
         else:

--- a/src/muon/muon_fsdp2.py
+++ b/src/muon/muon_fsdp2.py
@@ -313,7 +313,7 @@ class TpFsdp2dWork:
     """
     
     def __init__(self, param, state, group, index: int):
-        raise NotImplementedError("TP + FSDP not implemented, use HsdpFsdp2dWork for HSDP")
+        raise NotImplementedError("TP + FSDP not implemented, use Hsdp2dWork for HSDP")
     
 class EpFsdp2dWork:
     """

--- a/train_hsdp.py
+++ b/train_hsdp.py
@@ -1,0 +1,304 @@
+from dataclasses import dataclass
+import os
+import time
+from typing import TYPE_CHECKING, Literal
+
+import torch
+import torch.distributed as dist
+from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy  # type: ignore
+from torch.distributed.device_mesh import init_device_mesh
+import wandb
+
+from zeroband.data import TEST_VOCAB_SIZE, DataConfig, get_dataloader
+from zeroband.lr_scheduler import get_scheduler
+from zeroband.models.llama import get_model
+from zeroband.models.llama.model import create_block_mask_from_seqlens
+from muon_fsdp2 import Muon
+from zeroband.utils import (
+    FakeTokenizer,
+    PerfCounter,
+    get_peak_flops,
+    get_num_params,
+    get_num_flop_per_token,
+    apply_ac_ckpt,
+)
+from zeroband.logger import get_logger
+
+from transformers import AutoTokenizer
+from pydantic_config import BaseConfig, parse_argv
+import torch.nn.functional as F
+
+from zeroband.world_info import get_world_info
+
+
+class MuonConfig(BaseConfig):
+    type: Literal["muon"] = "muon"
+    lr: float = 2e-2
+    wd: float = 0.01
+    momentum: float = 0.95
+    ns_steps: int = 5
+
+
+class OptimConfig(BaseConfig):
+    optim: MuonConfig = MuonConfig()
+    sched_type: Literal["cosine", "linear", "wsd-sqrt"] = "cosine"
+    warmup_steps: int = 1000
+    stable_steps: int = 80_000
+    total_steps: int = 88_000
+    batch_size: int = 512
+
+
+class TrainConfig(BaseConfig):
+    micro_bs: int = 1
+    ac_ckpt: bool | int = False
+    reshard_after_forward: bool = True  # old shard grad op True mean full shard
+    torch_compile: bool = True
+
+
+class Config(BaseConfig):
+    name_model: Literal["debugmodel", "70M", "150M", "271M", "1B", "7B", "10B", "13B", "26B", "70B"] = "150M"
+    type_model: Literal["llama2", "llama3"] = "llama3"
+
+    project: str = "prime_simple"
+    wandb: bool = True
+
+    data: DataConfig = DataConfig()
+    optim: OptimConfig = OptimConfig()
+    train: TrainConfig
+
+
+@dataclass
+class TrainingProgress:
+    total_tokens: int
+    outer_step: int
+    step: int
+
+
+def train(config: Config):
+    # batch_size is the total batch size for all GPUs
+    assert config.optim.batch_size % world_info.local_world_size == 0
+    batch_size = config.optim.batch_size // world_info.local_world_size
+
+    assert batch_size % config.train.micro_bs == 0, (
+        f"The micro batch size ({config.train.micro_bs}) must divide the number of samples on each GPU ({batch_size})."
+    )
+    gradient_accumulation_steps = batch_size // config.train.micro_bs
+
+    # Load tokenizer
+    if config.data.fake and config.name_model == "debugmodel":
+        tokenizer = FakeTokenizer()
+    elif config.type_model == "llama2":
+        tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1", use_fast=True)
+    elif config.type_model == "llama3":
+        tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B", use_fast=True)
+    else:
+        raise ValueError(f"Model type {config.type_model} not supported")
+
+    train_dataloader = get_dataloader(
+        tokenizer=tokenizer,
+        world_size=world_info.world_size,
+        rank=world_info.rank,
+        batch_size=config.train.micro_bs,
+        data_config=config.data,
+    )
+    train_dataloader_iterator = iter(train_dataloader)
+
+    model, model_config = get_model(
+        type_model=config.type_model,
+        name_model=config.name_model,
+        seq_length=config.data.seq_length,
+        vocab_size=len(tokenizer) if config.name_model != "debugmodel" or not config.data.fake else TEST_VOCAB_SIZE,
+    )
+
+    gpu_peak_flops = get_peak_flops(torch.cuda.get_device_name(torch.device("cuda")))
+    logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
+
+    num_params = get_num_params(model, exclude_embedding=True)
+    logger.info(f"Number of parameters: {num_params}")
+    num_flop_per_token = get_num_flop_per_token(
+        num_params,
+        model_config,
+        config.data.seq_length,
+    )
+
+    if config.train.ac_ckpt:
+        num = 1 if isinstance(config.train.ac_ckpt, bool) else config.train.ac_ckpt
+        apply_ac_ckpt(model, num)
+
+    mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
+
+    # Initialize 2D device mesh for HSDP
+    # Requires multi-node setup (nnodes > 1)
+    if world_info.nnodes == 1:
+        raise ValueError(
+            "train_hsdp.py requires multi-node training (nnodes > 1). "
+            "For single-node training, use train_fsdp.py instead."
+        )
+    
+    # Create 2D mesh: (replicas across nodes, shards within node)
+    mesh = init_device_mesh(
+        "cuda",
+        mesh_shape=(world_info.nnodes, world_info.local_world_size),
+        mesh_dim_names=("replicate", "shard")
+    )
+    logger.info(
+        f"Initialized HSDP 2D mesh: {world_info.nnodes} replicas x {world_info.local_world_size} shards per node"
+    )
+
+    # Apply FSDP with HSDP mesh
+    for layer_id, transformer_block in model.layers.items():
+        if config.train.reshard_after_forward:
+            reshard_after_forward = int(layer_id) < len(model.layers) - 1
+        else:
+            reshard_after_forward = False
+        fully_shard(
+            transformer_block,
+            mesh=mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward
+        )
+    fully_shard(
+        model,
+        mesh=mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=config.train.reshard_after_forward
+    )
+
+    hidden_matrix_params = [p for n, p in model.layers.named_parameters() if p.ndim >= 2 and "embed" not in n]
+    embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+    scalar_params = [p for p in model.parameters() if p.ndim < 2]
+    head_params = [model.output.weight]
+
+    # init the optimizer(s)
+    # Adam parameter groups
+    adam_groups = [
+        dict(params=head_params, lr=0.008, use_muon=False, betas=(0.8, 0.95), eps=1e-10),
+        dict(params=embed_params, lr=0.6, use_muon=False, betas=(0.8, 0.95), eps=1e-10),
+        dict(params=scalar_params, lr=0.04, use_muon=False, betas=(0.8, 0.95), eps=1e-10),
+    ]
+
+    # Muon parameter group
+    muon_group = dict(
+        params=hidden_matrix_params,
+        lr=config.optim.optim.lr,
+        momentum=config.optim.optim.momentum,
+        ns_steps=config.optim.optim.ns_steps,
+        weight_decay=config.optim.optim.wd,
+        use_muon=True,
+    )
+
+    # Single unified optimizer
+    optimizer = Muon([*adam_groups, muon_group])
+    optimizers = [optimizer]
+
+    schedulers = [
+        get_scheduler(
+            sched_type=config.optim.sched_type,
+            optimizer=optimizer,
+            num_warmup_steps=config.optim.warmup_steps,
+            num_stable_steps=config.optim.stable_steps,
+            num_training_steps=config.optim.total_steps,
+        )
+        for optimizer in optimizers
+    ]
+
+    training_progress = TrainingProgress(total_tokens=0, outer_step=0, step=0)
+
+    if world_info.rank == 0 and config.wandb:
+        wandb.init(project=config.project, config=config.model_dump())
+
+    if config.train.torch_compile:
+        model = torch.compile(model) if not TYPE_CHECKING else model
+
+    perf_counter = PerfCounter(window_size=10)
+
+    while True:
+        loss_batch = 0
+
+        for grad_acc_step in range(gradient_accumulation_steps):
+            is_accumulating = grad_acc_step < gradient_accumulation_steps - 1
+            # no sync if we are accumulating gradients
+            model.set_requires_gradient_sync(not is_accumulating)
+
+            batch = next(train_dataloader_iterator)
+            input_ids = batch["input_ids"].to("cuda")
+            labels = batch["labels"].to("cuda")
+            seqlens = [seqlen.to("cuda") for seqlen in batch["seqlens"]]
+            block_mask = create_block_mask_from_seqlens(seqlens) if seqlens is not None else None
+
+            logits = model(tokens=input_ids, block_mask=block_mask).contiguous()
+            flatten_logits = logits.reshape(-1, logits.size(-1))  # b seq vocab -> (b * seq) vocab
+            flatten_labels = labels.reshape(-1)  # b seq -> (b * seq)
+
+            ce_loss = F.cross_entropy(flatten_logits, flatten_labels)
+
+            del logits
+            del flatten_logits
+            del flatten_labels
+
+            loss = ce_loss / gradient_accumulation_steps
+            loss.backward()
+            loss_batch += loss.detach().clone()
+
+        dist.all_reduce(tensor=loss_batch, op=dist.ReduceOp.AVG)
+
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0).full_tensor()  # type: ignore (is a dtensor)
+
+        for optimizer, scheduler in zip(optimizers, schedulers):
+            optimizer.step()
+            scheduler.step()
+
+            optimizer.zero_grad()
+
+        # logging
+        training_progress.step += 1
+        inner_lr = [group["lr"] for group in optimizers[0].param_groups][0]
+
+        # syncing loss across all data parallel rank within a nodes
+        new_tokens = config.data.seq_length * config.optim.batch_size
+        perf_counter.count_tokens(new_tokens)
+        training_progress.total_tokens += new_tokens
+
+        metrics = {
+            "Loss": loss_batch.item(),
+            "step": training_progress.step,
+            "inner_lr": inner_lr,
+            "Perplexity": torch.exp(loss_batch).item(),
+            "total_tokens": training_progress.total_tokens,
+            "time": time.time(),
+            "grad_norm": grad_norm.item(),
+        }
+
+        log = f"step: {training_progress.step}, loss: {loss_batch.item():.4f}"
+
+        tokens_per_second = perf_counter.get_tokens_per_second()
+        if tokens_per_second is not None:
+            metrics["tokens_per_second"] = tokens_per_second
+            metrics["mfu"] = 100 * num_flop_per_token * tokens_per_second / gpu_peak_flops / world_info.local_world_size
+            log += f", tokens_per_second: {tokens_per_second:.2f}, mfu: {metrics['mfu']:.2f}"
+
+        if world_info.rank == 0 and config.wandb:
+            wandb.log(metrics)
+
+        logger.info(log)
+
+        if training_progress.step > config.optim.total_steps:
+            break
+
+    logger.info("Training finished, exiting ...")
+
+
+if __name__ == "__main__":
+    # Allow eager fallback during production so that that the training runs dont die
+    # However, in development, we want to know that we broke torch compile
+    torch._dynamo.config.suppress_errors = "ZERO_BAND_DEV" not in os.environ  # type: ignore
+    torch.set_float32_matmul_precision("high")
+    torch.manual_seed(42)
+
+    config = Config(**parse_argv())  # type: ignore
+    world_info = get_world_info()
+    logger = get_logger()
+
+    torch.cuda.set_device(world_info.local_rank)
+
+    train(config)

--- a/train_hsdp.py
+++ b/train_hsdp.py
@@ -1,3 +1,6 @@
+# Multi-node training script with HSDP (Hybrid Sharded Data Parallel) support
+# Based on train_fsdp.py with 2D mesh initialization for multi-node setups
+
 from dataclasses import dataclass
 import os
 import time


### PR DESCRIPTION
### Purpose
Adds Hybrid Sharded Data Parallel (HSDP) support for efficient multi-node training.

### Changes
- Add `Hsdp2dWork` class in `muon_fsdp2.py` for 2D mesh (replicas × shards)
- Add `train_hsdp.py` for multi-node training with HSDP
- Update README with HSDP usage examples

### Usage
```bash
# Node 0
uv run torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 \
  --master_addr=<node0_ip> --master_port=<port> \
  train_hsdp.py @ configs/150M/H100.toml

# Node 1
uv run torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 \
  --master_addr=<node0_ip> --master_port=<port> \
  train_hsdp.py @ configs/150M/H100.toml
```